### PR TITLE
modifications to grammar and output format

### DIFF
--- a/channels.py
+++ b/channels.py
@@ -1,21 +1,15 @@
-from typing import List, Dict, Optional
-
 import logging
-import cachetools  # type: ignore
 import random
 
 from query import Query, QueryStateDict
-from queries import query_json_api
 from tree import Result
 
-from . import AnswerTuple, LatLonTuple
+# TODO: Channel ID dict?
 
-_SIMINN_QTYPE = "Channel"
+_TV_CHANNEL_QTYPE = "TV-Channel"
 
-TOPIC_LEMMAS = [
-    "RÚV",
-    "Sjónvarp Símans"
-]
+TOPIC_LEMMAS = ["RÚV", "Sjónvarp Símans"]
+
 
 def help_text(lemma: str) -> str:
     """Help text to return when query.py is unable to parse a query but
@@ -32,68 +26,69 @@ def help_text(lemma: str) -> str:
         )
     )
 
+
 # This module wants to handle parse trees for queries
 HANDLE_TREE = True
 
 # The grammar nonterminals this module wants to handle
-QUERY_NONTERMINALS = {"QChannel"}
+QUERY_NONTERMINALS = {"QTVChannel"}
 
 # The context-free grammar for the queries recognized by this plug-in module
 GRAMMAR = """
 
 Query →
-    QChannel
+    QTVChannel
 
-QChannel → QChannelQuery '?'?
+QTVChannel → QTVChannelQuery '?'?
 
-QChannelQuery →
-    QChannelRUV | QChannelSS 
-    | QChannelStod2 | QChannelStod2Fjolskylda | QChannelStod2Bio
-    | QChannelHringbraut | QChannelStod2Visir | QChannelRUV2
-    | QChannelSiminnSport | QChannelSiminnSport2 | QChannelSiminnSport3 | QChannelSiminnSport4
-    | QChannelAlthing | QChannelOmega
-    | QChannelStod2Sport | QChannelStod2Sport2 | QChannelStod2Sport3 | QChannelStod2Sport4
-    | QChannelStod2eSport | QChannelStod2Golf
+QTVChannelQuery →
+    QTVChannelRUV | QTVChannelSS
+    | QTVChannelStod2 | QTVChannelStod2Fjolskylda | QTVChannelStod2Bio
+    | QTVChannelHringbraut | QTVChannelStod2Visir | QTVChannelRUV2
+    | QTVChannelSiminnSport | QTVChannelSiminnSport2 | QTVChannelSiminnSport3 | QTVChannelSiminnSport4
+    | QTVChannelAlthing | QTVChannelOmega
+    | QTVChannelStod2Sport | QTVChannelStod2Sport2 | QTVChannelStod2Sport3 | QTVChannelStod2Sport4
+    | QTVChannelStod2eSport | QTVChannelStod2Golf
 
-QChannelRUV →
+QTVChannelRUV →
     "rúv" | 'ríkisútvarp'/fall | "stöð" "eitt" | "einn"
 
-QChannelSS →
+QTVChannelSS →
     "sjónvarp" "símans" | "sjónvarp" 'síminn'/fall | "sjónvarp" 'sími:no'/fall | "sjónvarp" "síminn" | "tveir"
 
-QChannelStod2 →
+QTVChannelStod2 →
     "stöð" QTwo
     | "studdu" QTwo
     | "studduð" QTwo
 
-QChannelStod2Fjolskylda →
-    QChannelStod2 "fjölskylda"
+QTVChannelStod2Fjolskylda →
+    QTVChannelStod2 "fjölskylda"
 
-QChannelStod2Bio →
-    QChannelStod2 "bíó"
+QTVChannelStod2Bio →
+    QTVChannelStod2 "bíó"
 
-QChannelHringbraut →
+QTVChannelHringbraut →
     "hringbraut"
 
-QChannelStod2Visir →
-    QChannelStod2 "vísir"
+QTVChannelStod2Visir →
+    QTVChannelStod2 "vísir"
 
-QChannelK100 →
+QTVChannelK100 →
     "ká" "hundrað"
 
-QChannelRUV2 →
-    QChannelRUV QTwo
+QTVChannelRUV2 →
+    QTVChannelRUV QTwo
 
-QChannelSiminnSport →
+QTVChannelSiminnSport →
     QSiminn QSport QOne?
 
-QChannelSiminnSport2 →
+QTVChannelSiminnSport2 →
     QSiminn QSport QTwo
 
-QChannelSiminnSport3 →
+QTVChannelSiminnSport3 →
     QSiminn QSport QThree
 
-QChannelSiminnSport4 →
+QTVChannelSiminnSport4 →
     QSiminn QSport QFour
 
 QOne →
@@ -111,109 +106,125 @@ QSiminn →
 QSport →
     "sport"
 
-QChannelAlthing →
+QTVChannelAlthing →
     "alþingi"
 
-QChannelOmega →
+QTVChannelOmega →
     "omega" | "ómega" | "Omega"
 
-QChannelStod2Sport →
-    QChannelStod2 QSport QOne?
-QChannelStod2Sport2 →
-    QChannelStod2 QSport QTwo
-QChannelStod2Sport3 →
-    QChannelStod2 QSport QThree
-QChannelStod2Sport4 →
-    QChannelStod2 QSport QFour
-QChannelStod2eSport →
-    QChannelStod2 "e" QSport
-QChannelStod2Golf →
-    QChannelStod2 "golf"
+QTVChannelStod2Sport →
+    QTVChannelStod2 QSport QOne?
+QTVChannelStod2Sport2 →
+    QTVChannelStod2 QSport QTwo
+QTVChannelStod2Sport3 →
+    QTVChannelStod2 QSport QThree
+QTVChannelStod2Sport4 →
+    QTVChannelStod2 QSport QFour
+QTVChannelStod2eSport →
+    QTVChannelStod2 "e" QSport
+QTVChannelStod2Golf →
+    QTVChannelStod2 "golf"
 
 """
 
-def QChannelQuery(node, params, result):
-    result.qtype = _SIMINN_QTYPE
 
-def QChannelRUV(node, params, result):
+def QTVChannelQuery(node, params, result):
+    result.qtype = _TV_CHANNEL_QTYPE
+
+
+def QTVChannelRUV(node, params, result):
     result["command"] = 22759586
 
-def QChannelSS(node, params, result):
+
+def QTVChannelSS(node, params, result):
     result["command"] = 22759594
 
-def QChannelStod2(node, params, result):
+
+def QTVChannelStod2(node, params, result):
     result["command"] = 22759599
 
-def QChannelStod2Fjolskylda(node, params, result):
+
+def QTVChannelStod2Fjolskylda(node, params, result):
     result["command"] = 22759572
 
-def QChannelStod2Bio(node, params, result):
+
+def QTVChannelStod2Bio(node, params, result):
     result["command"] = 22759610
 
-def QChannelHringbraut(node, params, result):
+
+def QTVChannelHringbraut(node, params, result):
     result["command"] = 40043140
 
-def QChannelStod2Visir(node, params, result):
+
+def QTVChannelStod2Visir(node, params, result):
     result["command"] = 22759598
 
-def QChannelRUV2(node, params, result):
+
+def QTVChannelRUV2(node, params, result):
     result["command"] = 46888903
 
-def QChannelSiminnSport(node, params, result):
+
+def QTVChannelSiminnSport(node, params, result):
     result["command"] = 46888998
 
-def QChannelSiminnSport2(node, params, result):
+
+def QTVChannelSiminnSport2(node, params, result):
     result["command"] = 46888999
 
-def QChannelSiminnSport3(node, params, result):
+
+def QTVChannelSiminnSport3(node, params, result):
     result["command"] = 46890006
 
-def QChannelSiminnSport4(node, params, result):
+
+def QTVChannelSiminnSport4(node, params, result):
     result["command"] = 46890007
 
-def QChannelAlthing(node, params, result):
+
+def QTVChannelAlthing(node, params, result):
     result["command"] = 22759659
 
-def QChannelOmega(node, params, result):
+
+def QTVChannelOmega(node, params, result):
     result["command"] = 22759667
 
-def QChannelStod2Sport(node, params, result):
+
+def QTVChannelStod2Sport(node, params, result):
     result["command"] = 22759619
 
-def QChannelStod2Sport2(node, params, result):
+
+def QTVChannelStod2Sport2(node, params, result):
     result["command"] = 22759656
 
-def QChannelStod2Sport3(node, params, result):
+
+def QTVChannelStod2Sport3(node, params, result):
     result["command"] = 22759600
 
-def QChannelStod2Sport4(node, params, result):
+
+def QTVChannelStod2Sport4(node, params, result):
     result["command"] = 22759643
 
-def QChannelStod2eSport(node, params, result):
+
+def QTVChannelStod2eSport(node, params, result):
     result["command"] = 46890013
 
-def QChannelStod2Golf(node, params, result):
-    result["command"] = 40043123
 
+def QTVChannelStod2Golf(node, params, result):
+    result["command"] = 40043123
 
 
 def sentence(state: QueryStateDict, result: Result) -> None:
     """Called when sentence processing is complete."""
     q: Query = state["query"]
-    if (
-        "qtype" in result
-        and result["qtype"] == _SIMINN_QTYPE
-    ):
+    if "qtype" in result and result["qtype"] == _TV_CHANNEL_QTYPE:
+        q.query_is_command()
         try:
-            print("))============>", _SIMINN_QTYPE, "<============((")
-            q.set_qtype(_SIMINN_QTYPE)
-            q.set_answer("", result["command"], "")
+            print("))============>", _TV_CHANNEL_QTYPE, "<============((")
+            q.set_qtype(_TV_CHANNEL_QTYPE)
+            ans = "CHANNEL;" + str(result["command"])
+            q.set_answer({"answer": ans}, ans)
             return
         except Exception as e:
-            logging.warning(
-                "Exception generating answer from Channels: {0}".format(e)
-            )
+            logging.warning("Exception generating answer from Channels: {0}".format(e))
             q.set_error("E_EXCEPTION: {0}".format(e))
     else:
         q.set_error("E_QUERY_NOT_UNDERSTOOD")
-    

--- a/search.py
+++ b/search.py
@@ -1,88 +1,157 @@
-from typing import List, Dict, Optional
-from islenska import Bin
-from reynir import Greynir
-
 import logging
-import cachetools  # type: ignore
 import random
 
 from query import Query, QueryStateDict
-from queries import query_json_api
 from tree import Result
-from reynir import NounPhrase
 
-from . import AnswerTuple, LatLonTuple
 
-_SIMINN_QTYPE = "Search"
+_TV_SEARCH_QTYPE = "TV-Search"
 
-TOPIC_LEMMAS = [
-    "finna"
-]
+TOPIC_LEMMAS = ["finna", "finndu", "hryllingsmyndir", "leita"]
+
 
 def help_text(lemma: str) -> str:
     """Help text to return when query.py is unable to parse a query but
     one of the above lemmas is found in it"""
     return "Ég get svarað ef þú spyrð til dæmis: {0}?".format(
-        random.choice(
-            (
-                "Finna Love Island",
-            )
-        )
+        random.choice(("Finndu Love Island",))
     )
+
+
+# Words for "movie"/"show"/"episode" in
+_CONTENT_TYPES_ACCUSATIVE = "|".join(
+    (
+        "myndina",
+        "kvikmyndina",
+        "þáttinn",
+        "þættina",
+        "sjónvarpsþáttinn",
+        "sjónvarps þáttinn",
+        "sjónvarpsþættina",
+        "sjónvarps þættina",
+        "þáttaröðina",
+        "seríuna",
+        "sjónvarpsseríuna",
+        "sjónvarps seríuna",
+    )
+)
+
+_CONTENT_TYPES_DATIVE = "|".join(
+    (
+        "myndinni",
+        "kvikmyndinni",
+        "þættinum",
+        "þáttunum",
+        "sjónvarpsþáttunum",
+        "sjónvarps þáttunum",
+        "sjónvarpsþættinum",
+        "sjónvarps þættinum",
+        "þáttaröðinni",
+        "seríunni",
+        "sjónvarpsseríunni",
+        "sjónvarps seríunni",
+    )
+)
 
 # This module wants to handle parse trees for queries
 HANDLE_TREE = True
 
 # The grammar nonterminals this module wants to handle
-QUERY_NONTERMINALS = {"QSearch"}
+QUERY_NONTERMINALS = {"QTVSearch"}
 
 # The context-free grammar for the queries recognized by this plug-in module
 GRAMMAR = """
 
-Query →
-    QSearch
+Query → QTVSearch
  
-QSearch → QSearchQuery '?'?
+QTVSearch → QTVSearchQuery '?'?
 
-QSearchQuery →
-    QSearchKeyword QSearchTerm
+QTVSearchQuery →
+    QTVSearchKeywordAcc QTVSearchTerm_þf
+    | QTVSearchKeywordDat QTVSearchTerm_þgf
+    # TODO: "myndum með x (í aðalhutverki)"
+    # TODO: Skipta efnisflokkum eftir premium og síminn bíó
 
-QSearchKeyword →
+QTVSearchKeywordAcc →
     "finna"
+    | "finndu"
+    | "sýndu" "mér"
 
-QSearchTerm →
-    Nl
+QTVSearchKeywordDat →
+    "leitaðu" "að"
+
+QTVSearchTerm_þf →
+    "hryllingsmyndir"
+    | "hasarmyndir"
+
+QTVSearchTerm_þgf →
+    "hryllingsmyndum"
+    | "hasarmynd"
+
+# QTVSearchTerm →
+#     Nl
 
 """
 
+# efnisflokkar premium efnis vs efnisflokkar siminn bio
+# PREMIUM
+# jól
+# kvikmyndir
+# íslenskt bíó
+# nýtt efni
+# krakkar
+# allar seríur
+# hámhorf
+# íslenskt
 
-def QSearchQuery(node, params, result):
-    result.qtype = _SIMINN_QTYPE
+# SÍMINN BÍÓ
+# jólabíó
+# nýjar
+# nýkomnar
+# krakkabíó
+# spenna
+# drama
+# gaman
+# rómantík
+# fjölskyldu
+# íslenskar
+# heimildarmyndir
+# indie
+# sci-fi
+# hrollvekjur
+# bíó paradís
+# leikarar
+# allir flokkar
 
-def QSearchTerm(node, params, result):
-    nl = NounPhrase(result._nominative)
-    try:
-        result["leit-angr"] = "{nl:ángr}".format(nl=nl)
-        result["leit-nf"] = "{nl:nf}".format(nl=nl)
-    except:
-        result["leit-angr"] = str(nl)
-        result["leit-nf"] = ""
+# response dæmi þeirra flokka sem skarast ekki á
+# "sýndu mér hryllingsmyndir"
+# "answer": ["hrollvekjur", "BIO"]
 
-    print("Nl:", nl)
+# "sýndu mér hámhorf"
+# "answer": ["hámhorf", "PREMIUM"]
+
+# íslenskur flokkur er t.d. til á bæði premium og bíó
+# "sýndu mér íslenskar myndir á premium"
+# "sýndu mér íslenskar myndir á síminn bíó/á leigunni"
+
+
+def QTVSearchQuery(node, params, result):
+    result.qtype = _TV_SEARCH_QTYPE
+
+def QTVSearchTerm(node, params, result):
+    result["command"] = ["hryllingsmyndir"]
 
 
 def sentence(state: QueryStateDict, result: Result) -> None:
     """Called when sentence processing is complete."""
     # if when not specified, default to today
     q: Query = state["query"]
-    if (
-        "qtype" in result
-        and result["qtype"] == _SIMINN_QTYPE
-    ):
+    if "qtype" in result and result["qtype"] == _TV_SEARCH_QTYPE:
         try:
-            print("))============>", _SIMINN_QTYPE, "<============((")
-            q.set_qtype(_SIMINN_QTYPE)
-            q.set_answer("", [result["leit-angr"], result["leit-nf"]], "")
+            q.set_qtype(_TV_SEARCH_QTYPE)
+            ans = ";".join(["SEARCH"] + result["command"])
+
+            q.set_answer({"answer": ans}, ans)
             return
         except Exception as e:
             logging.warning(

--- a/timetravel.py
+++ b/timetravel.py
@@ -1,24 +1,15 @@
-from typing import List, Dict, Optional
-from islenska import Bin
-from reynir import Greynir
-
 import logging
-import cachetools  # type: ignore
 import random
 
 from query import Query, QueryStateDict
-from queries import query_json_api
-from tree import Result
-from reynir import NounPhrase
+from tree import Node, ParamList, Result
 
-from . import AnswerTuple, LatLonTuple
+_TV_TIMETRAVEL_QTYPE = "TV-Timetravel"
+_STARTOVER_CMD = "STARTOVER"
 
-_TIMETRAVEL_QTYPE = "Timetravel"
-_STARTOVER_QTYPE = "Startover"
 
-TOPIC_LEMMAS = [
-    "spila"
-]
+TOPIC_LEMMAS = ["spila", "byrjun", "byrja"]
+
 
 def help_text(lemma: str) -> str:
     """Help text to return when query.py is unable to parse a query but
@@ -26,141 +17,128 @@ def help_text(lemma: str) -> str:
     return "Ég get svarað ef þú spyrð til dæmis: {0}?".format(
         random.choice(
             (
-                "Spila Gísla Martein í kvöld",
+                "Spilaðu Kastljós",
                 "Spila Kiljuna frá í gær",
                 "Spila Tíufréttir frá því í fyrradag",
             )
         )
     )
 
+
 # This module wants to handle parse trees for queries
 HANDLE_TREE = True
 
 # The grammar nonterminals this module wants to handle
-QUERY_NONTERMINALS = {"QTimeTravel", "QStartOver"}
+QUERY_NONTERMINALS = {"QTVTimeTravel"}
 
 # The context-free grammar for the queries recognized by this plug-in module
 GRAMMAR = """
 
-Query →
-    QTimeTravel | QStartOver
+Query → QTVTimeTravel
  
-QTimeTravel → QTimeTravelQuery '?'?
+QTVTimeTravel → QTVTimeTravelQuery '?'?
 
-QStartOver → QStartOverQuery '?'?
+QTVTimeTravelQuery →
+    QTVStartOver
+    | QTVTimeTravelKeyword QTVTimeTravelProgram QTVTimeTravelSinceWhen?
 
-QTimeTravelQuery →
-    QTimeTravelKeyword QTimeTravelProgram QTimeTravelWhen?
-
-QStartOverQuery →
+QTVStartOver →
     "byrja" "upp" "á" "nýtt"
-    | "byrja" "byrjun"
+    | "byrja" "frá" "byrjun"
+    | "aftur" "á" "byrjun"
 
-QTimeTravelCourtesy →
-    "getur" 
-    | "getur" "þú" 
+QTVTimeTravelCourtesy →
+    "getur" "þú"?
     | "geturðu" 
 
-QTimeTravelKeyword →
-    "spila" | "spilar" | "spilaðu" | "spilað"  | "spilaði"
+QTVTimeTravelKeyword →
+    "spila"
+    | "spilar"
+    | "spilaðu"
+    | "spilað"
+    | "spilaði"
 
-QTimeTravelAtviksord →
-    "í" | "á" | "við" | "þau" | "þú"
+# QTVTimeTravelAtviksord →
+#     "í" | "á" | "við" | "þau" | "þú"
 
-QTimeTravelProgram →
+QTVTimeTravelProgram →
     Nl
 
-QTimeTravelSince →
+QTVTimeTravelSinceWhen →
+    QTVTimeTravelSince? QTVTimeTravelWhen
+
+QTVTimeTravelSince →
     "síðan" 
     | "frá" 
     | "frá" "það" 
     | "frá" "því"
 
-QTimeTravelWhen →
-    QTimeTravelToday | QTimeTravelYesterday | QTimeTravelDayBeforeYesterday
+QTVTimeTravelWhen →
+    QTVTimeTravelToday
+    | QTVTimeTravelYesterday
+    | QTVTimeTravelDayBeforeYesterday
 
-QTimeTravelToday →
-    "í" "dag"
+QTVTimeTravelToday →
+    "í" "dag" | "í_kvöld"
 
-QTimeTravelYesterday →
-    "í_gær" | "geir" | "hér"
+QTVTimeTravelYesterday →
+    "í_gær"
+    # | "geir"
+    # | "hér"
 
-QTimeTravelDayBeforeYesterday →
+QTVTimeTravelDayBeforeYesterday →
   "í_fyrradag"
 
 """
 
 
-def QTimeTravelQuery(node, params, result):
-    result.qtype = _TIMETRAVEL_QTYPE
-
-def QStartOverQuery(node, params, result):
-    result.qtype = _STARTOVER_QTYPE
-
-def QTimeTravelProgram(node, params, result):
-    nl = NounPhrase(result._nominative)
-    try:
-        result["program-angr"] = "{nl:ángr}".format(nl=nl)
-        result["program-nf"] = "{nl:nf}".format(nl=nl)
-    except:
-        result["program-angr"] = str(nl)
-        result["program-nf"] = ""
-
-    print("Nl:", nl)
+def QTVTimeTravelQuery(node, params, result):
+    result.qtype = _TV_TIMETRAVEL_QTYPE
 
 
-def QTimeTravelToday(node, params, result):
-    result["when"] = "today"
+def QTVStartOver(node, params, result):
+    result["qkey"] = _STARTOVER_CMD
 
 
-def QTimeTravelYesterday(node, params, result):
-    result["when"] = "yesterday"
+def QTVTimeTravelProgram(node: Node, params: ParamList, result: Result):
+    text: str = result._text.lower()
+    if text.endswith(" frá því") or text.endswith(" frá því í dag"):
+        text = text[: text.rfind(" frá því")]
+
+    result["command"] = [text]
 
 
-def QTimeTravelDayBeforeYesterday(node, params, result):
-    result["when"] = "daybeforeyesterday"
+def QTVTimeTravelToday(node, params, result):
+    result["when"] = ["today"]
+
+
+def QTVTimeTravelYesterday(node, params, result):
+    result["when"] = ["yesterday"]
+
+
+def QTVTimeTravelDayBeforeYesterday(node, params, result):
+    result["when"] = ["daybeforeyesterday"]
 
 
 def sentence(state: QueryStateDict, result: Result) -> None:
     """Called when sentence processing is complete."""
     # if when not specified, default to today
-    """
-    try:
-        result["when"]
-    except:
-        result["when"] = "today"
-    """
     if "when" not in result:
-        result["when"] = "today"
+        result["when"] = ["today"]
 
     q: Query = state["query"]
-    if (
-        "qtype" in result
-        and result["qtype"] == _TIMETRAVEL_QTYPE
-    ):
+    if "qtype" in result and result["qtype"] == _TV_TIMETRAVEL_QTYPE:
         try:
-            print("))============>", _TIMETRAVEL_QTYPE, "<============((")
-            q.set_qtype(_TIMETRAVEL_QTYPE)
-            q.set_answer("", [result["when"], result["program-angr"], result["program-nf"]], "")
+            q.query_is_command()
+            q.set_qtype(_TV_TIMETRAVEL_QTYPE)
+            if "qkey" in result and result["qkey"] == _STARTOVER_CMD:
+                q.set_answer({"answer": _STARTOVER_CMD}, _STARTOVER_CMD, "")
+            else:
+                ans = ";".join(["TIMETRAVEL"] + result["command"] + result["when"])
+                q.set_answer({"answer": ans}, ans)
             return
         except Exception as e:
-            logging.warning(
-                "Exception generating answer from Timetravel: {0}".format(e)
-            )
-            q.set_error("E_EXCEPTION: {0}".format(e))
-    elif (
-        "qtype" in result
-        and result["qtype"] == _STARTOVER_QTYPE
-    ):
-        try:
-            print("))============>", _STARTOVER_QTYPE, "<============((")
-            q.set_qtype(_STARTOVER_QTYPE)
-            q.set_answer("", "startover", "")
-            return
-        except Exception as e:
-            logging.warning(
-                "Exception generating answer from TVCP: {0}".format(e)
-            )
+            logging.warning("Exception generating answer from TVCP: {0}".format(e))
             q.set_error("E_EXCEPTION: {0}".format(e))
     else:
         q.set_error("E_QUERY_NOT_UNDERSTOOD")

--- a/volume.py
+++ b/volume.py
@@ -1,40 +1,175 @@
-from typing import List, Dict, Optional, Mapping
+from typing import List, Mapping, cast
 
 import logging
-import cachetools  # type: ignore
+import json
 import random
-import math
-import re
 
 from query import Query, QueryStateDict
-from queries import query_json_api
-from tree import Result
-from reynir import NounPhrase
+from tree import Node, OptionalNode, ParamList, Result, TerminalNode
 
-from . import AnswerTuple, LatLonTuple
 
-_SIMINN_QTYPE = "Volume"
+_TV_VOLUME_QTYPE = "TV-Volume"
 
 TOPIC_LEMMAS = [
     "hækka",
+    "hækkaðu",
     "lækka",
+    "lækkaðu",
     "þögn",
     "þagna",
     "hljóð",
     "hljóðstyrkur",
 ]
 
+
+def help_text(lemma: str) -> str:
+    """Help text to return when query.py is unable to parse a query but
+    one of the above lemmas is found in it"""
+    return "Ég get svarað ef þú spyrð til dæmis: {0}?".format(
+        random.choice(
+            (
+                "Hækka hljóðið",
+                "Lækka hljóðstyrkinn",
+                "Hækka",
+                "Þagna",
+                "Þögn",
+                "Hljóð fimmtíu prósent",
+            )
+        )
+    )
+
+
+# This module wants to handle parse trees for queries
+HANDLE_TREE = True
+
+# The grammar nonterminals this module wants to handle
+QUERY_NONTERMINALS = {"QTVVolume"}
+
+# The context-free grammar for the queries recognized by this plug-in module
+GRAMMAR = """
+
+Query → QTVVolume
+
+QTVVolume → QTVVolumeQuery '?'?
+
+QTVVolumeQuery →
+    QTVVolumeRelative
+    | QTVVolumeAbsolute
+
+# "hækkaðu um tuttugu prósent", "lækkaðu um fimmtíu og einn"
+QTVVolumeRelative →
+    QTVVolumeIncrease QTVVolumeHljóð? QTVVolumeUmAmount?
+    | QTVVolumeDecrease QTVVolumeHljóð? QTVVolumeUmAmount?
+
+QTVVolumeUmAmount → "um"? QTVVolumeAmount
+
+# "stilltu hljóðið í fimmtíu prósent", "settu hljóðið í tuttugu"
+QTVVolumeAbsolute →
+    QTVVolumeSet? QTVVolumeHljóð "í"? QTVVolumeAmount
+    | "hækkaðu" "í" QTVVolumeAmount
+    | "lækkaðu" "í" QTVVolumeAmount
+
+QTVVolumeIncrease →
+    "hækka" "þú"?
+    | "hækkaðu"
+    | "hækkað"
+    # | "fækka"
+
+QTVVolumeDecrease →
+    "lækka" "þú"?
+    | "lækkaðu"
+    | "lækkað"
+    | "lægra"
+    | "lægri"
+    | "minnka" "þú"?
+    | "minnkaðu"
+
+QTVVolumeSet →
+    "stilltu"
+    | "stilla"
+    | "setja"
+    | "settu"
+
+
+QTVVolumeHljóð →
+    "hljóð"
+    | "hljóðið"
+    | "hljóðstyrk"
+    | "hljóðstyrkinn"
+
+QTVVolumeAmount →
+    QTVVolumePercent
+    | QTVVolumeNumber "prósent"?
+
+QTVVolumePercent →
+    Prósenta
+    | QTVVolumeNumTens "og" Prósenta
+
+
+QTVVolumeNumber →
+    QTVVolumeNum0
+    | QTVVolumeNum1To9
+    | QTVVolumeNum10To19
+    | QTVVolumeNumTens
+    | QTVVolumeNumTens "og" QTVVolumeNum1To9
+    | QTVVolumeNum100
+
+QTVVolumeNum0 → "núll"
+
+QTVVolumeNum1To9 →
+    'einn:to'
+    | 'tveir:to'
+    | 'þrír:to'
+    | 'fjórir:to'
+    | "fimm"
+    | "sex"
+    | "sjö"
+    | "átta"
+    | "níu"
+
+QTVVolumeNum10To19 →
+    "tíu"
+    | "ellefu"
+    | "tólf"
+    | "þrettán"
+    | "fjórtán"
+    | "fimmtán"
+    | "sextán"
+    | "sautján"
+    | "átján"
+    | "nítján"
+
+QTVVolumeNumTens →
+    "tuttugu"
+    | "þrjátíu"
+    | "fjörutíu"
+    | "fjörtíu"
+    | "fimmtíu"
+    | "sextíu"
+    | "sjötíu"
+    | "áttatíu"
+    | "níutíu"
+
+QTVVolumeNum100 →
+    "eitt"? "hundrað"
+
+"""
+
 _NUMBER_WORDS: Mapping[str, float] = {
     "núll": 0,
     "einn": 1,
     "einu": 1,
+    "eitt": 1,
     "tveir": 2,
     "tveim": 2,
+    "tvö": 2,
     "þrír": 3,
     "þrem": 3,
+    "þrjú": 3,
     "þremur": 3,
     "fjórir": 4,
     "fjórum": 4,
+    "fjögur": 4,
     "fimm": 5,
     "sex": 6,
     "sjö": 7,
@@ -53,6 +188,7 @@ _NUMBER_WORDS: Mapping[str, float] = {
     "tuttugu": 20,
     "þrjátíu": 30,
     "fjörutíu": 40,
+    "fjörtíu": 40,
     "fimmtíu": 50,
     "sextíu": 60,
     "sjötíu": 70,
@@ -62,130 +198,115 @@ _NUMBER_WORDS: Mapping[str, float] = {
     "hundruð": 100,
 }
 
-def help_text(lemma: str) -> str:
-    """Help text to return when query.py is unable to parse a query but
-    one of the above lemmas is found in it"""
-    return "Ég get svarað ef þú spyrð til dæmis: {0}?".format(
-        random.choice(
-            (
-                "Hækka hljóðið",
-                "Lækka hljóðstyrkinn",
-                "Hækka",
-                "Þagna",
-                "Þögn!",
-                "hljóð fimmtíu prósent"
-            )
-        )
-    )
 
-# This module wants to handle parse trees for queries
-HANDLE_TREE = True
+def QTVVolumeQuery(node: Node, params: ParamList, result: Result) -> None:
+    result.qtype = _TV_VOLUME_QTYPE
 
-# The grammar nonterminals this module wants to handle
-QUERY_NONTERMINALS = {"QVolume"}
 
-# The context-free grammar for the queries recognized by this plug-in module
-GRAMMAR = """
+def Prósenta(node: Node, params: ParamList, result: Result) -> None:
+    tnode: OptionalNode = node.first_child(lambda x: x.has_t_base("prósenta"))
+    if tnode:
+        tnode = cast(TerminalNode, tnode)
+        # Extract number value from percentage terminal node
+        result["numbers"] = [json.loads(tnode.aux)[0]]
 
-Query →
-    QVolume
- 
-QVolume → QVolumeQuery '?'?
 
-QVolumeQuery →
-    QVolumeUpQuery QVolumeVolume?
-    | QVolumeDownQuery QVolumeVolume?
-    | QVolumeVolume QVolumePercent
+def QTVVolumeNum0(node: Node, params: ParamList, result: Result) -> None:
+    result["numbers"] = [0]
 
-QVolumeUpQuery →
-    "hækka" | "hækka" "þú" | "hækkaðu" | "hækkað" 
-    | "fækka"
 
-QVolumeDownQuery →
-    "lækka" | "lækkað" | "lækka" "þú" | "lækkaðu" 
+def QTVVolumeNum1To9(node: Node, params: ParamList, result: Result) -> None:
+    r = _NUMBER_WORDS.get(result._root)
+    if r:
+        result["numbers"] = [r]
 
-QVolumeVolume →
-    "hljóð" | "hljóðið" | "hljóðstyrk" | "hljóðstyrkinn"
 
-QVolumePercent → Prósenta
+def QTVVolumeNum10To19(node: Node, params: ParamList, result: Result) -> None:
+    r = _NUMBER_WORDS.get(result._root)
+    if r:
+        result["numbers"] = [r]
 
-"""
 
-def QVolumePercent(node, params, result):
-    result._canonical = result._text
-    n = result._text.split()
-    print(result._canonical)
-    print("N:", n, type(n))
-    # skoda rett control flow
-    # hvad gaeti fokkad thessu upp?
-    if n[0].isdecimal():
-        print(n[0], "is decimal")
-        result["command"] = int(n[0])           # 8
-    elif n[0] in _NUMBER_WORDS:
-        print(n[0], "is not decimal")
-        result["command"] = _NUMBER_WORDS[n[0]] # átta
+def QTVVolumeNumTens(node: Node, params: ParamList, result: Result) -> None:
+    r = _NUMBER_WORDS.get(result._root)
+    if r:
+        result["numbers"] = [r]
+
+
+def QTVVolumeNum100(node: Node, params: ParamList, result: Result) -> None:
+    result["numbers"] = [100]
+
+
+def QTVVolumeIncrease(node: Node, params: ParamList, result: Result) -> None:
+    result["command"] = ["VOLUME_REL"]
+
+
+def QTVVolumeDecrease(node: Node, params: ParamList, result: Result) -> None:
+    result["command"] = ["VOLUME_REL"]
+    result["negative"] = True
+
+
+def QTVVolumeAbsolute(node: Node, params: ParamList, result: Result) -> None:
+    result["command"] = ["VOLUME_ABS"]
+
+
+def _parse_numbers(result: Result) -> int:
+    """
+    Parse numbers in query/command and
+    combine into a single number.
+    """
+    nums: List[int] = result.get("numbers", [])
+
+    if len(nums) == 0:
+        # By default the volume increment is just 1
+        return 1
+
+    if len(nums) == 1:
+        final_num = nums[0]
+    elif len(nums) >= 2:
+        n1, n2 = nums
+
+        if 19 < n1 < 100 and n1 % 10 == 0 and 0 < n2 < 10:
+            # Normal, e.g. "fimmtíu og eitt prósent"
+            final_num = n1 + n2
+        else:
+            # Weird queries, e.g. "tuttugu og þrjátíu prósent"
+            # Just ignore first number and take second one
+            final_num = n2
     else:
-        print("tjah, hvað er í gangi hér?")
+        return 1
 
-def QVolumeQuery(node, params, result):
-    result.qtype = _SIMINN_QTYPE
+    # Keep number in range 0-100
+    if final_num < 0:
+        final_num = 0
+    elif final_num > 100:
+        final_num = 100
 
+    if "negative" in result and result["negative"]:
+        # Lowering the volume
+        final_num = -final_num
 
-def QVolumeUpQuery(node, params, result):
-    result["command"] = "VOLUME_UP"
+    return int(final_num)
 
-
-def QVolumeDownQuery(node, params, result):
-    result["command"] = "VOLUME_DOWN"
-
-
-def QVolumeMuteQuery(node, params, result):
-    result["command"] = "MUTE"
-
-
-def parse_num(num_str: str) -> float:
-    # Parse Icelandic number string to float or int
-    num = None
-    try:
-        # Pi
-        if num_str == "pí":
-            num = math.pi
-        # Handle numbers w. Icelandic decimal places ("17,2")
-        elif re.search(r"^\d+,\d+$", num_str):
-            num = float(num_str.replace(",", "."))
-        # Handle digits ("17")
-        else:
-            num = float(num_str)
-    except ValueError:
-        # Handle number words ("sautján")
-        if num_str in _NUMBER_WORDS:
-            num = _NUMBER_WORDS[num_str]
-        # Ordinal number strings ("17.")
-        elif re.search(r"^\d+\.$", num_str):
-            num = int(num_str[:-1])
-        else:
-            num = 0
-    except Exception as e:
-        logging.warning("Unexpected exception: {0}".format(e))
-        raise
-    return num
 
 def sentence(state: QueryStateDict, result: Result) -> None:
     """Called when sentence processing is complete."""
     q: Query = state["query"]
-    if (
-        "qtype" in result
-        and result["qtype"] == _SIMINN_QTYPE
-    ):
+    if "qtype" in result and result["qtype"] == _TV_VOLUME_QTYPE:
         try:
-            print("))============>", _SIMINN_QTYPE, "<============((")
-            q.set_qtype(_SIMINN_QTYPE)
-            q.set_answer("", result["command"], "")
+            q.query_is_command()
+            q.set_qtype(_TV_VOLUME_QTYPE)
+
+            cmd_list: List[str] = result["command"]
+            cmd_list.append(str(_parse_numbers(result)))
+
+            # Return the command as a string delimited by semicolons
+            # Format: (VOLUME_REL|VOLUME_ABS);<value>
+            ans = ";".join(cmd_list)
+            q.set_answer({"answer": ans}, ans)
             return
         except Exception as e:
-            logging.warning(
-                "Exception generating answer from Volume: {0}".format(e)
-            )
+            logging.warning("Exception generating answer from Volume: {0}".format(e))
             q.set_error("E_EXCEPTION: {0}".format(e))
     else:
         q.set_error("E_QUERY_NOT_UNDERSTOOD")


### PR DESCRIPTION
(Note: I'm still working on the modules.)
The main changes I implemented that are relevant to the react application are the return values from Greynir.

The react code should now entirely rely on `answer`, not `qtype`. `answer` is now a `;` delimited string, of the form `COMMAND;ARG1;ARG2;...`. (The reason the answer isn't simply a list is because Greynir assumes `answer` is a string). My idea was to split on `;` in the react code and use the first part (`COMMAND`) to determine which endpoint to call and extracting the following arguments (`ARG1;...`) to use in those functions.